### PR TITLE
Fix com.alibaba.nacos.common.utils.JacksonUtilsTest.testToJsonBytes1 flaky test

### DIFF
--- a/common/src/test/java/com/alibaba/nacos/common/utils/JacksonUtilsTest.java
+++ b/common/src/test/java/com/alibaba/nacos/common/utils/JacksonUtilsTest.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -473,7 +474,8 @@ public class JacksonUtilsTest {
         Assert.assertEquals("你好，中国！", restResult.getData().get("string"));
         Assert.assertEquals(999, restResult.getData().get("integer"));
     }
-    
+
+    @JsonPropertyOrder({ "aLong", "aInteger", "aBoolean"})
     static class TestOfAtomicObject {
         
         public AtomicLong aLong = new AtomicLong(0);
@@ -557,7 +559,8 @@ public class JacksonUtilsTest {
             return result;
         }
     }
-    
+
+    @JsonPropertyOrder({ "value", "key"})
     static class TestOfGetter {
         
         public String getKey() {


### PR DESCRIPTION
The existing test is flaky because it relies on the ordering of properties while serializing a POJO object.
To fix it, use @JsonPropertyOrder annotation which fixes the order.
We can then write our tests with the order in mind.

The flaky tests were found by running NonDex (https://github.com/TestingResearchIllinois/NonDex).